### PR TITLE
AppImage: do not integrate into system

### DIFF
--- a/dist/AppImageBuilder.yml
+++ b/dist/AppImageBuilder.yml
@@ -18,8 +18,7 @@ AppDir:
     exec_args: $@
 
   after_runtime: |
-    echo "X-AppImage-Integrate=false" | tee -a "${TARGET_APPDIR}/org.v1993.evdevhook2.desktop"
-    echo "Test file" | tee -a "${TARGET_APPDIR}/test_file.txt"
+    echo "X-AppImage-Integrate=false" >> "{{APPIMAGE_PATH}}/org.v1993.evdevhook2.desktop"
 
   apt:
     arch:

--- a/dist/AppImageBuilder.yml
+++ b/dist/AppImageBuilder.yml
@@ -17,6 +17,10 @@ AppDir:
     exec: usr/bin/evdevhook2
     exec_args: $@
 
+  after_runtime: |
+    echo "X-AppImage-Integrate=false" | tee -a "${TARGET_APPDIR}/org.v1993.evdevhook2.desktop"
+    echo "Test file" | tee -a "${TARGET_APPDIR}/test_file.txt"
+
   apt:
     arch:
       - "{{APPIMAGE_APT_ARCH}}"


### PR DESCRIPTION
This is recommended since we're a command line tool. Fixes #4.