### PR TITLE
CI: Integrate changes from linuxmotehook2

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -5,9 +5,11 @@ env:
   UBUNTU_PUBKEY: 871920D1991BC93C
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
+  push:
+    branches: main
+  release:
+    types: published
 
 jobs:
   build:

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -46,17 +46,16 @@ jobs:
           TARGET_PLATFORM: ${{ matrix.platform }}
         shell: bash
         run: |
-          set -eu
-          find build -mindepth 1 -maxdepth 1 -type d | while read -r path; do
-            set -a
-            APPIMAGE_SOURCE="${path}"
-            APPIMAGE_VERSION="${GITHUB_REF_SLUG}"
-            APPIMAGE_APT_ARCH="${TARGET_PLATFORM#*/}"
-            APPIMAGE_APT_DISTRO="${UBUNTU_RELEASE}"
-            APPIMAGE_APT_PUBKEY="${UBUNTU_PUBKEY}"
-            APPIMAGE_ARCH="$(basename "${path}")"
-            printenv | grep ^APPIMAGE_ >>"${GITHUB_ENV}"
-          done
+          set -eua
+          . build/.build-metadata.env
+          rm build/.build-metadata.env
+          APPIMAGE_SOURCE=build
+          APPIMAGE_VERSION="${GITHUB_REF_SLUG}"
+          APPIMAGE_APT_ARCH="${TARGETARCH}"
+          APPIMAGE_APT_DISTRO="${UBUNTU_RELEASE}"
+          APPIMAGE_APT_PUBKEY="${UBUNTU_PUBKEY}"
+          APPIMAGE_ARCH="${TARGETMACHINE}"
+          printenv | grep ^APPIMAGE_ >>"${GITHUB_ENV}"
 
       - name: Build AppImage
         uses: AppImageCrafters/build-appimage@v1.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,19 @@ COPY . /
 
 ARG BUILD_TYPE=release
 ARG ENABLE_LTO=true
+ARG TARGETOS TARGETARCH TARGETVARIANT
 
 RUN meson setup \
+      --fatal-meson-warnings \
       "--buildtype=${BUILD_TYPE}" \
       "-Db_lto=${ENABLE_LTO}" \
-      "--prefix=/usr" \
+      --prefix=/usr \
       /build && \
     meson compile -C /build && \
-    meson install --destdir="/release/$(uname -m)" -C /build
+    meson install --destdir=/release -C /build
+
+RUN export "TARGETMACHINE=$(uname -m)" && \
+    printenv | grep ^TARGET >>/release/.build-metadata.env
 
 FROM scratch AS export-stage
-
-COPY --from=build-stage /release/ /
+COPY --from=build-stage /release/ /release/.build-metadata.env /

--- a/dist/AppImageBuilder.yml
+++ b/dist/AppImageBuilder.yml
@@ -7,7 +7,9 @@ script:
   mkdir -p "${icon_path}"
   cp -a dist/evdevhook2.png "${icon_path}"
   # Manual installation is required until fix of https://github.com/AppImageCrafters/build-appimage/issues/5
-  apt-get update && apt-get install -y --no-install-recommends squashfs-tools
+  if ! command -v mksquashfs >/dev/null; then
+    apt-get update && apt-get install -y --no-install-recommends squashfs-tools
+  fi
 
 AppDir:
   app_info:


### PR DESCRIPTION
Changes from linuxmotehook2 are integrated as [requested](https://github.com/v1993/linuxmotehook2/pull/17#issuecomment-1730661520).

The build argument `--fatal-meson-warnings` is part of this, I hope this is OK.